### PR TITLE
Update to way api works and endpoints are leveraged.

### DIFF
--- a/aquasec/_version.py
+++ b/aquasec/_version.py
@@ -1,3 +1,3 @@
 """Version"""
 
-__version__ = "0.0.1rc7"
+__version__ = "0.0.1rc8"

--- a/aquasec/api.py
+++ b/aquasec/api.py
@@ -18,6 +18,9 @@ class API:
     """
     cloudsploit_url: str = "https://api.cloudsploit.com/{}/{}"
     workload_url: str = "{}/api/{}/{}"
+    api_version: str = "" # set on initialization
+    # Endpoints for CSPM going away from this
+    # TODO: Remove the endpoint capability and just use the direct csmp get()
     endpoint_alerts: str = "alerts"
     endpoint_apikeys: str = "apikeys"
     endpoint_auditlogs: str = "auditlogs"

--- a/aquasec/get.py
+++ b/aquasec/get.py
@@ -13,19 +13,21 @@ if not config.SET_LOG:
 
 
 class Get:
-    """Get Class for Aquasec
-
-    Returns:
-        _type_: _description_
+    """Get Class for Aquasec CSPM and Workload Protection
     """
     _parent_class = None
     method: str = "GET"
 
     def cspm(self, url_path: str, **kwargs):
-        """_summary_
+        """Creates CSPM endpoint. Pass any paremters required to complete the Request.
+
+        Args:
+            url_path (str, required): The URL resource path. Ex "alerts"
+            params (dict, optional): RestAPI parameters
+            api_version (str, optional): Defaults to configured version
 
         Returns:
-            _type_: _description_
+            dict: JSON results
         """
         api_version: str = kwargs.pop("api_verison", self._parent_class.api_version)  # type: ignore
         url = self._parent_class.cloudsploit_url.format(  # type:ignore
@@ -37,13 +39,17 @@ class Get:
         return response
 
     def workload_protection(self, url_path: str, **kwargs):
-        """Workload Protection Requests
+        """Workload Protection Requests, see README.md for some assistance here.
+            this is difficult to get as there is no documentation and most is pulled
+            from the cloud portal. But there are some examples to help on readme.
 
         Args:
-            endpoint (str): _description_
+            url_path (str): The URL Resource path. Ex: "risks/bench/{id}/bench_results"
+            api_version (str, optional): Overrides the version set in the configuration
+            params (dict, Optional): required params for request see README for examples
 
         Returns:
-            _type_: _description_
+            dict: JSON results
         """
         try:
             api_version: str = kwargs.pop(
@@ -72,7 +78,8 @@ class Get:
         Returns:
             str: _description_
         """
-        api_version: str = kwargs.pop('api_version', self._parent_class.api_version)  # type :ignore
+        api_version: str = kwargs.pop(
+            'api_version', self._parent_class.api_version)  # type: ignore # type :ignore
         url = self._parent_class.cloudsploit_url.format(api_version, url_path)  # type: ignore
         return url
 


### PR DESCRIPTION
Changed how the API functios to allow it to be more flexable due to how the api endpoints are made availbable. Also, added some test examples in the readme to help explain it. Instead of building out each endpoint the known endpoint path can be sent through the auth system that is created in the backend. So, for workload you continue using the same key until its calculaed expiration time; for cspm there is a different token and key that needs to be used with adifferent endpoints. They can be found on their webiste, so instead of listing them you can pass the reuqired parameters and endpoint paths and it will create and build the rest endpoint to retrieve the data.